### PR TITLE
FEAT : 게시판 타입 및 유저 타입에 따른 게시글 작성 권한 제어

### DIFF
--- a/src/main/java/zb/Team/showticket/board/controller/BoardController.java
+++ b/src/main/java/zb/Team/showticket/board/controller/BoardController.java
@@ -48,7 +48,10 @@ public class BoardController {
     public SingleResult<Post> post(@RequestHeader(name = "AUTH-TOKEN") String token, @PathVariable String boardName, @Valid @ModelAttribute PostDto post) {
         UserVo vo = provider.getUserVo(token);
         Long id = vo.getId();
-        return responseService.getSingleResult(boardService.writePost(id, boardName, post));
+        String email = vo.getEmail();
+        return responseService.getSingleResult(boardService.writePost(id,email, boardName, post));
+
+        //id를 검증해서 유저타입<->보드타입 비교 후 보드서비스로 넘겨주기
     }
 
     @ApiOperation(value = "게시판 글 수정", notes = "게시판의 단건 게시글을 수정한다.")
@@ -56,6 +59,7 @@ public class BoardController {
     public SingleResult<Post> post(@RequestHeader(name = "AUTH-TOKEN") String token, @PathVariable long postId, @Valid @ModelAttribute PostDto post) {
         UserVo vo = provider.getUserVo(token);
         Long id = vo.getId();
+
         return responseService.getSingleResult(boardService.updatePost(postId, id, post));
     }
 

--- a/src/main/java/zb/Team/showticket/board/domain/entity/Board.java
+++ b/src/main/java/zb/Team/showticket/board/domain/entity/Board.java
@@ -19,4 +19,6 @@ public class Board extends BaseEntity{
     private Long boardId;
     @Column(nullable = false)
     private String name;
+    @Column(nullable = false)
+    private String boardType;
 }

--- a/src/main/java/zb/Team/showticket/board/domain/entity/Post.java
+++ b/src/main/java/zb/Team/showticket/board/domain/entity/Post.java
@@ -18,39 +18,47 @@ import javax.persistence.*;
 //리뷰게시글
 public class Post extends BaseEntity {
 
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long postId;
-        @Column(nullable = false, length = 100)
-        private String title;
-        @Column(length = 500)
-        private String content;
 
-        @ManyToOne(fetch = FetchType.EAGER)
-        @JoinColumn(name = "board_id")
-        private Board board; // 게시글 - 게시판의 관계 - N:1
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+    @Column(nullable = false, length = 100)
+    private String title;
+    @Column(length = 500)
+    private String content;
 
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "board_id")
+    private Board board; // 게시글 - 게시판의 관계 - N:1
+    private String board_name;
+    private String board_type;
 
-        @ManyToOne(fetch = FetchType.EAGER)
-        @JoinColumn(name = "user_id")
-        private Users user;  // 게시글 - 회원의 관계 - N:1
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id")
+    private Users user;  // 게시글 - 회원의 관계 - N:1
+    private String user_type;
+    private String user_name;
 
-        protected Board getBoard() {
-            return board;
-        }
+    protected Board getBoard() {
+        return board;
+    }
 
-        // 생성자
-        public Post(Users user,Board board, String title, String content) {
-            this.user = user;
-            this.board = board;
-            this.title = title;
-            this.content = content;
-        }
+    // 생성자
+    public Post(Users user, Board board, String title, String content) {
+        this.user = user;
+        this.user_name = user.getName();
+        this.board = board;
+        this.board_name = board.getName();
+        this.board_type = board.getBoardType();
+        this.title = title;
+        this.content = content;
+        this.user_type = user.getType();
+    }
 
-        // 수정시 데이터 처리
-        public Post setUpdate(String title, String content) {
-            this.title = title;
-            this.content = content;
-            return this;
-        }
+    // 수정시 데이터 처리
+    public Post setUpdate(String title, String content) {
+        this.title = title;
+        this.content = content;
+        return this;
+    }
 }

--- a/src/main/java/zb/Team/showticket/board/responsehandler/ResponseService.java
+++ b/src/main/java/zb/Team/showticket/board/responsehandler/ResponseService.java
@@ -9,7 +9,7 @@ public class ResponseService {
 
     // enum으로 api 요청 결과에 대한 code, message를 정의합니다.
     public enum CommonResponse {
-        SUCCESS(0, "성공하였습니디."),
+        SUCCESS(0, "성공하였습니다."),
         FAIL(-1, "실패하였습니다.");
 
         int code;

--- a/src/main/java/zb/Team/showticket/board/service/BoardService.java
+++ b/src/main/java/zb/Team/showticket/board/service/BoardService.java
@@ -11,6 +11,7 @@ import zb.Team.showticket.user.domain.entity.Users;
 import zb.Team.showticket.user.domain.repository.UserRepository;
 import zb.Team.showticket.user.exception.CustomException;
 import zb.Team.showticket.user.exception.ErrorCode;
+import zb.Team.showticket.user.service.UserService;
 
 import java.util.List;
 import java.util.Optional;
@@ -43,11 +44,18 @@ public class BoardService {
     }
 
     // 게시글 등록
-    public Post writePost(Long id, String boardName, PostDto postDto) {
+    public Post writePost(Long id,String email, String boardName, PostDto postDto) {
         Board board = findBoard(boardName);
-        Post post = new Post(userRepository.findById(id).
+        String btype = board.getBoardType();
+
+        Post post = new Post(userRepository.findByIdAndEmail(id,email).
                 orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER))
                 , board, postDto.getTitle(), postDto.getContent());
+
+        // user 타입과 게시판 타입이 일치하지 않을경우 예외발생
+        if (!post.getUser_type().contains(btype)){
+            throw new CustomException(ErrorCode.NOT_MACTH_USERTYPE);
+        }
         return postRepository.save(post);
     }
 
@@ -55,8 +63,9 @@ public class BoardService {
     public Post updatePost(long postId, Long id, PostDto postDto) {
         Post post = getPost(postId);
         Users user = post.getUser();
-        if (!id.equals(user.getId()))
+        if (!id.equals(user.getId())){
             throw new CustomException(ErrorCode.WRONG_MATCH_USER);
+        }
         post.setUpdate(postDto.getTitle(), postDto.getContent());
         return postRepository.save(post);
     }

--- a/src/main/java/zb/Team/showticket/user/domain/entity/Users.java
+++ b/src/main/java/zb/Team/showticket/user/domain/entity/Users.java
@@ -47,7 +47,7 @@ public class Users extends BaseEntity{
                 .name(form.getName())
                 .phone(form.getPhone())
                 .birth(form.getBirth())
-                .type("user")
+                .type("user,all")
                 .verify(false)
                 .credit(0)
                 .build();

--- a/src/main/java/zb/Team/showticket/user/domain/entity/Users.java
+++ b/src/main/java/zb/Team/showticket/user/domain/entity/Users.java
@@ -29,6 +29,7 @@ public class Users extends BaseEntity{
     private String password;
     private String phone;
     private LocalDate birth;
+    private String type;
 
     //email verify
     private LocalDateTime verifyExpiredAt;
@@ -46,7 +47,9 @@ public class Users extends BaseEntity{
                 .name(form.getName())
                 .phone(form.getPhone())
                 .birth(form.getBirth())
+                .type("user")
                 .verify(false)
+                .credit(0)
                 .build();
     }
 }

--- a/src/main/java/zb/Team/showticket/user/domain/model/UserDto.java
+++ b/src/main/java/zb/Team/showticket/user/domain/model/UserDto.java
@@ -17,8 +17,9 @@ public class UserDto {
     private Long id;
     private String name;
     private Integer credit;
+    private String type;
 
     public static UserDto from(Users users){
-        return new UserDto(users.getEmail(),users.getId(), users.getName(), users.getCredit());
+        return new UserDto(users.getEmail(),users.getId(), users.getName(), users.getCredit(), users.getType());
     }
 }

--- a/src/main/java/zb/Team/showticket/user/domain/repository/UserRepository.java
+++ b/src/main/java/zb/Team/showticket/user/domain/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<Users,Long> {
 
     Optional<Users> findByEmail(String email);
 
+    Optional<Users> findByIdAndEmail(Long id, String email);
 }

--- a/src/main/java/zb/Team/showticket/user/exception/ErrorCode.java
+++ b/src/main/java/zb/Team/showticket/user/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     //board
     WRONG_MATCH_USER(HttpStatus.BAD_REQUEST,"게시글 작성자가 아닙니다."),
     NOT_FOUND_REVIEWS(HttpStatus.BAD_REQUEST,"게시글이 존재하지 않습니다."),
-    NOT_FOUND_BOARD(HttpStatus.BAD_REQUEST,"게시판이 존재하지 않습니다.");
+    NOT_FOUND_BOARD(HttpStatus.BAD_REQUEST,"게시판이 존재하지 않습니다."),
+    NOT_MACTH_USERTYPE(HttpStatus.BAD_REQUEST,"현재 유저타입으로는 해당 게시판 작성이 불가합니다");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/zb/Team/showticket/user/service/UserService.java
+++ b/src/main/java/zb/Team/showticket/user/service/UserService.java
@@ -2,8 +2,8 @@ package zb.Team.showticket.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import zb.Team.showticket.user.domain.repository.UserRepository;
 import zb.Team.showticket.user.domain.entity.Users;
+import zb.Team.showticket.user.domain.repository.UserRepository;
 
 import java.util.Optional;
 


### PR DESCRIPTION
**Changes**
---

**AS-IS**
- users 내 user_type 으로 provider 와 user 구분
- board type 과 user type 이 일치하지 않는 경우 게시글 작성 불가(ex: 일반 회원이 공연 게시판에 공연 게시글 작성 불가,
단 user와 provider 공통으로 사용 가능한 board의 경우 type에 all을 부여하여 모두 접근 가능) 

**TO-BE**
- 

### **테스트**

- [ ]  테스트 코드
- [x]  API 테스트